### PR TITLE
Fix name for compbrlTable setting.

### DIFF
--- a/doc/liblouisxml.texi
+++ b/doc/liblouisxml.texi
@@ -758,7 +758,7 @@ contracted or uncontracted.
 The table used for producing uncontracted or Grade One braille. This
 setting appears to be superfluous and may be eliminated in the future.
 
-@setting{compbrailleTable, en-us-compbrl.ctb}
+@setting{compbrlTable, en-us-compbrl.ctb}
 The table used for producing large amounts of output in computer
 braille, such as computer programs. The computer braille table is
 usually combined with one of the two tables above.


### PR DESCRIPTION
The setting name was compbrailleTable but in the program it's not. This is supported by the setting in /usr/local/share/liblouisxml/lbx_files/canonical.cfg.
Took me agest to figure out why my config wasn't working! :P