### PR TITLE
Remove explicit detection of pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,8 +49,6 @@ AM_PROG_LIBTOOL
 AC_CHECK_PROG([HELP2MAN], [help2man], [help2man])
 AM_CONDITIONAL([HAVE_HELP2MAN], [test x$HELP2MAN = xhelp2man])
 
-AC_PATH_PROG(PKG_CONFIG, pkg-config)
-
 PKG_CHECK_MODULES(BASE_DEPENDENCIES, [liblouis, libxml-2.0])
 
 # Checks for libraries.


### PR DESCRIPTION
PKG_CHECK_MODULES already does it, and with support for cross-compilation,
so we should not try to detect pkg-config by hand, it only reduces support.